### PR TITLE
Moves tl:dr to bottom of the channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-## Too Long; Didn't Read
+## Welcome to Programming Discussions!
 
-- Be nice. Be mature. Follow the law. Listen
-to the mods. Ask your question directly (*don't ask to
-ask*) and don't post across multiple channels or ask
-people for programming help in DMs.
-- For more information, visit <https://progdisc.club>
+- Welcome to Programming Discussions. Below you will find the rules and necessary
+   information about our Discord server. We encourage you to have a look before
+   continuing.
+
+- For more information, visit <https://progdisc.club/>
+
+- You can use <https://invite.progdisc.club> to invite your friends!
 
 ## Rules
 
@@ -172,3 +174,10 @@ accuse a Mod of abuse.
 
 4. If you disagree with the actions of a Mod, first take it to that Mod’s DMs.
    You may follow up with another Mod if you still feel unsatisfied.
+
+## Too Long; Didn't Read
+
+- Be nice. Be mature. Follow the law. Listen
+to the mods. Ask your question directly (*don't ask to
+ask*) and don't post across multiple channels or ask
+people for programming help in DMs.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-## Welcome to Programming Discussions!
-
-- Welcome to Programming Discussions. Below you will find the rules and necessary
-   information about our Discord server. We encourage you to have a look before
-   continuing.
-
-- For more information, visit <https://progdisc.club/>
-
-- You can use <https://invite.progdisc.club> to invite your friends!
-
 ## Rules
 
 1. Follow the Discord service guidelines: <https://discordapp.com/guidelines>
@@ -181,3 +171,5 @@ accuse a Mod of abuse.
 to the mods. Ask your question directly (*don't ask to
 ask*) and don't post across multiple channels or ask
 people for programming help in DMs.
+
+- For more information, visit <https://progdisc.club>

--- a/main.js
+++ b/main.js
@@ -112,12 +112,6 @@ client.on('ready', async () => {
                 embed.setAuthor(title, guild.iconURL, `https://progdisc.club/rules/#${mdFragment}`);
             }
 
-            if (i === 0) {
-                embed.setAuthor(guild.name, guild.iconURL, 'https://progdisc.club');
-                embed.setFooter('Updated on');
-                embed.setTimestamp(new Date());
-            }
-
             embed.setColor('#4286F4');
             embed.setDescription(embedTexts[i][k]);
             await channel.send('', embed);


### PR DESCRIPTION
This currently needs reviewing. I have moved tl:dr to the bottom of the markdown, however the automated script depends on the first segment to put "Updated on" text and https://progdisc.club url on the title and it overrides the title text with "Programming Discussions", if Rules section is to stay at top, the "Updated on" text would stay between the first and second embed as Rules section is too large for a single embed, or we can modify the script to not do any of these things as an alternative.