### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ disruptive or a detriment to the culture of the server, we will remove you.
    discussion into redundant and/or conflicting answers. Directing people to
    your question is a better strategy than reposting it.
 
-- <https://www.nohello.com/>
-- <https://codingkilledthecat.wordpress.com/2012/06/26/how-to-ask-for-programming-help/>
+<https://www.nohello.com/><br>
+<https://codingkilledthecat.wordpress.com/2012/06/26/how-to-ask-for-programming-help/>
 
 ## #security channel
 


### PR DESCRIPTION
the current formatting is broken in the embedded message, rendering the link https://codingkilledthecat.wordpress.com/2012/06/26/how-to-ask-for-programming-help/ half-missing in the channel and unusable. 

I'm not sure if this change will fix the embed or further break it, but it's a start.